### PR TITLE
Add network-bind into plugs.

### DIFF
--- a/terraform/snap/snapcraft.yaml
+++ b/terraform/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 apps:
   terraform:
     command: terraform
-    plugs: [home, network]
+    plugs: [home, network, network-bind]
 
 parts:
   terraform:


### PR DESCRIPTION
terraform by default utilize local socket for communication between process with provider. Without network-bind access, the process will hang and die.